### PR TITLE
Add res.send(...) to close client response

### DIFF
--- a/app.js
+++ b/app.js
@@ -93,6 +93,7 @@ app.post('/collect', function(req, res){
 		function(error, resp, body){
 		console.log(error);
 	})
+	res.send("OK")
 });
 
 //Start Server


### PR DESCRIPTION
This call is required other the client invoking the /collect endpoint remains busy and does not end the request/response. 
