### PR TITLE
Use correct parameters for custom dimension and metric in payload

### DIFF
--- a/app.js
+++ b/app.js
@@ -68,15 +68,15 @@ app.post('/collect', function(req, res){
 		cid: 	user.id,
 		ds:  	"slack", //data source
 		cs: 	"slack", // campaign source
-		cd1: 	user.id,
-		cd2: 	channel.name,
-		cd3: 	msgText,
-		cm1: 	wordCount,
-		cm2: 	emojiCount,
-		cm3: 	exclaCount,
-	//	cm4: 	letterCount,
-		cm5: 	elipseCount, 
-		cm6: 	questionMark, //need to set up in GA
+		dimension1: 	user.id,
+		dimension2: 	channel.name,
+		dimension3: 	msgText,
+		metric1: 	wordCount,
+		metric2: 	emojiCount,
+		metric3: 	exclaCount,
+	//	metric4: 	letterCount,
+		metric5: 	elipseCount, 
+		metric6: 	questionMark, //need to set up in GA
 		dh:		teamDomain+".slack.com",
 		dp:		"/"+channel.name,
 		dt:		"Slack Channel: "+channel.name,


### PR DESCRIPTION
Custom dimension and metric data is not collected in Google Analytics because it's not using the
correct parameters in the payload. This change makes use of the `dimension[0-9]+` and `metric[0-9]+` format as per: https://developers.google.com/analytics/devguides/collection/analyticsjs/custom-dims-mets#overview
