### PR TITLE
Add User-Agent header to post request

### DIFF
--- a/app.js
+++ b/app.js
@@ -88,11 +88,18 @@ app.post('/collect', function(req, res){
 	};
 	console.log(JSON.stringify(data));
 	console.log(req.body);
-	//Make Post Request	
-	request.post("https://www.google-analytics.com/collect?" + qs.stringify(data), 
-		function(error, resp, body){
-		console.log(error);
-	})
+	//Make Post Request
+
+	var request_options = {
+		url: 'https://www.google-analytics.com/collect?' + qs.stringify(data),
+		headers: { 'User-Agent': 'slackalytics.js' }
+	}
+
+	function request_callback(error, resp, body) {
+		if (error) { console.log(error); }
+	}
+
+	request.post(request_options, request_callback)
 	res.send("OK")
 });
 


### PR DESCRIPTION
This adds the User-Agent header ('slackalytics.js') to the post request as per:
https://developers.google.com/analytics/devguides/collection/protocol/v1/reference#using-post
